### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/pkg/ghclient/wrappers_test.go
+++ b/pkg/ghclient/wrappers_test.go
@@ -282,7 +282,7 @@ func newFakeIssueService(org, repo string, labels []string, issueCount int) *fak
 	repoIssues := map[int]*github.Issue{}
 	for i := 1; i <= issueCount; i++ {
 		iCopy := i
-		text := fmt.Sprintf("%d", i)
+		text := strconv.Itoa(i)
 		issue := &github.Issue{
 			Title:     &text,
 			Body:      &text,

--- a/prow/cmd/deck/badge_test.go
+++ b/prow/cmd/deck/badge_test.go
@@ -65,7 +65,7 @@ func TestRenderBadge(t *testing.T) {
 		jobs := []prowapi.ProwJob{}
 		for i, state := range tc.jobStates {
 			jobs = append(jobs, prowapi.ProwJob{
-				Spec:   prowapi.ProwJobSpec{Job: fmt.Sprintf("%d", i+1)},
+				Spec:   prowapi.ProwJobSpec{Job: strconv.Itoa(i + 1)},
 				Status: prowapi.ProwJobStatus{State: prowapi.ProwJobState(state)},
 			})
 		}

--- a/prow/crier/controller_test.go
+++ b/prow/crier/controller_test.go
@@ -100,7 +100,9 @@ func (fakeInformer) GetController() cache.Controller                            
 func (fakeInformer) LastSyncResourceVersion() string                                           { return "" }
 func (fakeInformer) AddIndexers(indexers cache.Indexers) error                                 { return nil }
 func (fakeInformer) GetIndexer() cache.Indexer                                                 { return nil }
-func (fakeInformer) List(selector labels.Selector) (ret []*prowv1.ProwJob, err error)          { return nil, nil }
+func (fakeInformer) List(selector labels.Selector) (ret []*prowv1.ProwJob, err error) {
+	return nil, nil
+}
 
 func TestController_Run(t *testing.T) {
 	tests := []struct {

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -224,7 +224,7 @@ func (ja *JobAgent) update() error {
 			ProwJob: j.ObjectMeta.Name,
 			BuildID: buildID,
 
-			Started:     fmt.Sprintf("%d", j.Status.StartTime.Time.Unix()),
+			Started:     strconv.Itoa(j.Status.StartTime.Time.Unix()),
 			State:       string(j.Status.State),
 			Description: j.Status.Description,
 			PodName:     j.Status.PodName,

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -320,7 +320,7 @@ func (c *Client) measure(method, path string, code int, start time.Time) {
 		return
 	}
 	c.metrics.RequestLatency.WithLabelValues(method, path).Observe(time.Since(start).Seconds())
-	c.metrics.Requests.WithLabelValues(method, path, fmt.Sprintf("%d", code)).Inc()
+	c.metrics.Requests.WithLabelValues(method, path, strconv.Itoa(code)).Inc()
 }
 
 // GetSkipMetrics fetches the data found in the provided path. It returns the

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -1364,7 +1364,7 @@ func TestTakeAction(t *testing.T) {
 				if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", i)); err != nil {
 					t.Fatalf("Error checking out new branch: %v", err)
 				}
-				if err := lg.AddCommit("o", "r", map[string][]byte{fmt.Sprintf("%d", i): []byte("WOW")}); err != nil {
+				if err := lg.AddCommit("o", "r", map[string][]byte{strconv.Itoa(i): []byte("WOW")}); err != nil {
 					t.Fatalf("Error adding commit: %v", err)
 				}
 				if err := lg.Checkout("o", "r", "master"); err != nil {


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```